### PR TITLE
RHCOS 4.20 enablement

### DIFF
--- a/argfile.conf
+++ b/argfile.conf
@@ -1,6 +1,6 @@
-RHCOS_VERSION=4.19.0-rc.4
-TARGET_IMAGE=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:14c4f4ac7588a7a12b37831bfa9dd0f0dfea65b1f19e6d99ca9f728b566f37cd
-BUILDER_IMAGE=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a99e0d0012dcfe149f635ca91a4de72fc3fe492b290b182368be33b29af62398
+RHCOS_VERSION=4.20.0-ec.4
+TARGET_IMAGE=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a7d1968af1b82381a796d24d56107e6301cdc4c5b96efc78d07f3dbcbca2af23
+BUILDER_IMAGE=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a93577130602e61853128f935df37b073aa2a1d263b37a5eb43476be420861f9
 D_ARCH=aarch64
 D_CONTAINER_VER=0
 D_DOCA_VERSION=3.0.0

--- a/assets/install-rhcos.sh
+++ b/assets/install-rhcos.sh
@@ -44,7 +44,7 @@ if [[ -f "$IGNITION" ]] && jq -e . "$IGNITION" >/dev/null 2>&1; then
     efibootmgr -b $(efibootmgr -v | grep "Red-Hat CoreOS GRUB" | awk '{print $1}' | cut -d' ' -f1) -B
   fi
 
-  efibootmgr -c -d $device -p 2 -l '\EFI\redhat\grubaa64.efi' -L "Red-Hat CoreOS GRUB"
+  efibootmgr -c -d $device -p 2 -l '\EFI\redhat\shimaa64.efi' -L "Red-Hat CoreOS GRUB"
 
   reboot
 else

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ git clone --recursive https://github.com/rh-ecosystem-edge/rhcos-bfb-builder.git
 ### Build the RHCOS image
 First use an openshift cluster to check the release image for the RHCOS version you want to build.
 ```bash
-export RHCOS_VERSION="4.19.0-rc.4"
+export RHCOS_VERSION="4.20.0-ec.4"
 
 export TARGET_IMAGE=$(oc adm release info --image-for rhel-coreos "quay.io/openshift-release-dev/ocp-release:"$RHCOS_VERSION"-aarch64")
 export BUILDER_IMAGE=$(oc adm release info --image-for driver-toolkit "quay.io/openshift-release-dev/ocp-release:"$RHCOS_VERSION"-aarch64")

--- a/rhcos-bfb.Containerfile
+++ b/rhcos-bfb.Containerfile
@@ -21,7 +21,6 @@ ARG D_OFED_BASE_URL="https://linux.mellanox.com/public/repo/doca/${D_DOCA_VERSIO
 ARG D_OFED_SRC_TYPE=""
 ARG D_SOC_BASE_URL="https://linux.mellanox.com/public/repo/doca/${D_DOCA_VERSION}/extras"
 
-RUN rm /etc/yum.repos.d/ubi.repo
 RUN KVER=$(ls /usr/lib/modules | head -n1) && \
     echo "KVER=$KVER" >> /kernelver.env  
 ARG D_OFED_SRC_ARCHIVE="MLNX_OFED_SRC-${D_OFED_SRC_TYPE}${D_OFED_VERSION}.tgz"
@@ -58,7 +57,7 @@ ENV HOME=/build
 
 WORKDIR /root
 
-RUN SRPMS=("bluefield_edac" "tmfifo" "pwr-mlxbf" "mlxbf-ptm" "gpio-mlxbf3" "mlxbf-bootctl" \
+RUN SRPMS=("tmfifo" "pwr-mlxbf" "mlxbf-ptm" "gpio-mlxbf3" "mlxbf-bootctl" \
   "mlxbf-pmc" "mlxbf-livefish" "mlxbf-gige" "mlx-trio" "ipmb-dev-int" "ipmb-host" "pinctrl-mlxbf3") && \
   wget -r -np -nd -A rpm -e robots=off "${D_SOC_BASE_URL}/SRPMS" --accept-regex="$(IFS='|'; echo "(${SRPMS[*]/%/.+\.rpm})")"
 
@@ -177,6 +176,7 @@ RUN dnf -y install \
   doca-openvswitch \
   doca-openvswitch-ipsec \
   doca-openvswitch-selinux-policy \
+  doca-openvswitch-test \
   doca-pcc-counters \
   doca-sdk-aes-gcm \
   doca-sdk-apsh \
@@ -245,7 +245,6 @@ RUN dnf -y install \
   mlnx-snap \
   mmc-utils \
   device-mapper \
-  edac-utils \
   lm_sensors \
   efibootmgr \
   i2c-tools \ 


### PR DESCRIPTION
This PR introduces RHCOS 4.20 build support.

Other changes:
- Removed `bluefield-edac` kernel module building.
- Removed `edac-utils` from EPEL and it's dependencies.
- Replaced the target EFI Shim.
- Installed `doca-openvswitch-test` that includes `doca-tcpdump`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated to RHCOS version 4.20.0-ec.4 across configuration, documentation, and installation scripts.

* **Bug Fixes**
  * Adjusted EFI bootloader path in the installation script for improved compatibility.

* **Chores**
  * Refined container image build process by updating package lists and removing unnecessary files.
  * Updated documentation to reflect the new RHCOS version in build instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->