### PR TITLE
update selinux policy and turn selinux on by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp*
 old*
 .vscode
 scratch.txt
+.idea

--- a/assets/doca-ovs_sfc.te
+++ b/assets/doca-ovs_sfc.te
@@ -5,9 +5,25 @@ require {
     type openvswitch_t;
     type openvswitch_var_run_t;
     type container_var_run_t;
+    type openvswitch_load_module_t;
+    type ifconfig_t;
+    type initrc_var_run_t;
+    type kmod_exec_t;
+    type rasdaemon_t;
+    type debugfs_t;
     class unix_stream_socket connectto;
     class sock_file write;
+    class netlink_rdma_socket { read write };
+    class capability sys_admin;
+    class process { noatsecure rlimitinh siginh };
+    class file { append getattr write ioctl };
+    class dir search;
 }
+
+allow openvswitch_t openvswitch_load_module_t:process { noatsecure rlimitinh siginh };
+allow openvswitch_t self:capability sys_admin;
+allow openvswitch_t self:netlink_rdma_socket { read write };
+allow openvswitch_t debugfs_t:dir search;
 
 allow container_t openvswitch_t:unix_stream_socket connectto;
 allow container_t container_var_run_t:unix_stream_socket connectto;
@@ -16,3 +32,9 @@ allow container_t openvswitch_var_run_t:unix_stream_socket connectto;
 allow container_t openvswitch_t:sock_file write;
 allow container_t container_var_run_t:sock_file write;
 allow container_t openvswitch_var_run_t:sock_file write;
+
+
+allow ifconfig_t initrc_var_run_t:file { append getattr ioctl };
+
+allow rasdaemon_t initrc_var_run_t:file { write ioctl };
+allow rasdaemon_t kmod_exec_t:file getattr;

--- a/rhcos-bfb-source.Containerfile
+++ b/rhcos-bfb-source.Containerfile
@@ -299,7 +299,6 @@ RUN chmod +x /usr/bin/reload_mlx.sh; \
   systemctl enable mlx_ipmid.service || true; \
   systemctl enable set_emu_param.service || true; \
   systemctl enable reload_mlx.service || true; \
-  sed -i 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config; \
   echo 'OVS_USER_ID="root:root"' >> /etc/sysconfig/openvswitch
 
 RUN bash /opt/mellanox/bfb/infojson.sh > /opt/mellanox/bfb/info.json

--- a/rhcos-bfb.Containerfile
+++ b/rhcos-bfb.Containerfile
@@ -204,7 +204,6 @@ RUN chmod +x /usr/bin/reload_mlx.sh; \
   systemctl enable mlx_ipmid.service || true; \
   systemctl enable set_emu_param.service || true; \
   systemctl enable reload_mlx.service || true; \
-  sed -i 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config; \
   echo 'OVS_USER_ID="root:root"' >> /etc/sysconfig/openvswitch
 
 RUN bash /opt/mellanox/bfb/infojson.sh > /opt/mellanox/bfb/info.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to ignore the `.idea` directory in version control.
  * Removed commands that set SELinux to permissive mode during container builds.

* **New Features**
  * Expanded SELinux policy with new permissions and type declarations, enhancing compatibility and access control for related processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->