### PR TITLE
Installer changes and fixes

### DIFF
--- a/assets/infojson.sh
+++ b/assets/infojson.sh
@@ -79,7 +79,6 @@ json_output=$(jq -n \
 odata_count=6
 
 if [ -e "/opt/mellanox/mlnx-fw-updater/firmware/mlxfwmanager_sriov_dis_aarch64_41686" ]; then
-    echo "Found mlxfwmanager_sriov_dis_aarch64_41686, adding BF2_NIC_FW to JSON output"
     let odata_count++
     BF2_NIC_FW_VERSION=$(/opt/mellanox/mlnx-fw-updater/firmware/mlxfwmanager_sriov_dis_aarch64_41686 --list 2> /dev/null | grep FW | head -1 | awk '{print $4}')
 

--- a/make_bfb.sh
+++ b/make_bfb.sh
@@ -41,7 +41,7 @@ buildbfb() {
     boot_desc=$(mktemp)
 
     printf "console=ttyAMA1 console=hvc0 console=ttyAMA0 earlycon=pl011,0x01000000 earlycon=pl011,0x01800000 initrd=initramfs" > "$boot_args"
-    printf "console=hvc0 console=ttyAMA0 earlycon=pl011,0x13010000 initrd=initramfs systemd.wants=install-rhcos.service $KERNEL_DBG_ARGS" > "$boot_args2"
+    printf "console=hvc0 console=ttyAMA0 earlycon=pl011,0x13010000 initrd=initramfs systemd.unit=basic.target systemd.wants=install-rhcos.service $KERNEL_DBG_ARGS" > "$boot_args2"
 
     printf "VenHw(F019E406-8C9C-11E5-8797-001ACA00BFC4)/Image" > "$boot_path"
     printf "Linux from rshim" > "$boot_desc"

--- a/rhcos-bfb-source.Containerfile
+++ b/rhcos-bfb-source.Containerfile
@@ -240,10 +240,8 @@ RUN dnf -y install --setopt=install_weak_deps=False \
   ucx-rdmacm \
   ucx-xpmem \
   acpid \
-  # bridge-utils \
   mstflint \
   mft-autocomplete \
-  mlnx-snap \
   mmc-utils \
   device-mapper \
   lm_sensors \
@@ -319,6 +317,6 @@ RUN rm /opt && ln -s /var/opt /opt; \
 
 LABEL "rhcos.version"="${RHCOS_VERSION}"
 LABEL "rhcos.doca.version"="${D_DOCA_VERSION}"
-LABEL "rhcos.doca.distro"="${D_DOCA_DISTRO}"
-LABEL "rhcos.ofed.version"="${D_OFED_VERSION}"
+# LABEL "rhcos.doca.distro"="${D_DOCA_DISTRO}"
 LABEL "com.coreos.osname"=rhcos
+LABEL "rhcos.custom.tag"="${IMAGE_TAG}"

--- a/rhcos-bfb.Containerfile
+++ b/rhcos-bfb.Containerfile
@@ -144,10 +144,8 @@ RUN dnf -y install --setopt=install_weak_deps=False \
   ucx-rdmacm \
   ucx-xpmem \
   acpid \
-  # bridge-utils \
   mstflint \
   mft-autocomplete \
-  mlnx-snap \
   mmc-utils \
   device-mapper \
   lm_sensors \


### PR DESCRIPTION
Changes:
- The bootable BFB will boot to `basic.target` as systemd's target.
- The installer will wipe the NVME and mmcblk partition tables before installing the OS as done in Nvidia's official BFBs.
- The installer will no longer update the BMC firmware, aligns with Nvidia's DPF.
- Added more rshim logging, to make some messages visible outside of the DPU.
- Removed a debug printing from infojson.sh causing broken JSON files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a function to clear the first 10 MB of partitions on storage devices during installation for improved preparation.

* **Bug Fixes**
  * Improved log consistency and error reporting during the installation process.

* **Chores**
  * Removed unused or unnecessary packages from container builds.
  * Updated container metadata labels for better clarity.
  * Disabled BMC component update steps in the installation script.
  * Adjusted kernel boot arguments to specify systemd boot target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->