### PR TITLE
fix: remove workaround for DOCA Version detection

### DIFF
--- a/assets/infojson.sh
+++ b/assets/infojson.sh
@@ -216,9 +216,6 @@ if (rpm -q doca-runtime > /dev/null 2>&1); then
     let odata_count++
     DOCA_SOURCE=$(rpm -q --queryformat "[%{NAME}-%{VERSION}-%{RELEASE}]" doca-runtime)
 
-    # WORKAROUND
-    DOCA_VERSION="3.1.0087"
-
     json_output=$( echo $json_output | jq \
     --arg odata_count "$odata_count" \
     --arg odata_id "/redfish/v1/UpdateService/SoftwareInventory/$odata_count" \


### PR DESCRIPTION
This workaround was required due to an issue in DPF's BFB version parsing

This bug is fixed in DPF rc.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The inventory now reports the actual installed DOCA version from the system package manager instead of a fixed value. This ensures accurate version information in exported JSON inventories and any connected dashboards or reports. Other inventory fields and structure remain unchanged, including the DOCA source. Improves reliability for audits, troubleshooting, and compliance checks, and ensures downstream tools reflect the correct DOCA version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->