### PR TITLE
Use latest public release of DOCA packages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,18 +51,19 @@ export PULL_SECRET=<path to pull secret file>
 
 Set Nvidia DPU stack versions:
 ```bash
-export DOCA_VERSION="3.1.0-rhel9.6"
-export DOCA_DISTRO=""
+export DOCA_VERSION="3.1.0"
+export DOCA_DISTRO="rhel9.6"
 ```
 
 ```bash
 podman build -f rhcos-bfb.Containerfile \
---authfile $PULL_SECRET \
---build-arg D_ARCH=aarch64 \
---build-arg D_DOCA_VERSION=$DOCA_VERSION \
---build-arg D_FINAL_BASE_IMAGE=$TARGET_IMAGE \
---build-arg D_DOCA_DISTRO=$DOCA_DISTRO \
---tag "rhcos-bfb:$RHCOS_VERSION-latest"
+  --authfile $PULL_SECRET \
+  --build-arg D_ARCH=aarch64 \
+  --build-arg D_DOCA_VERSION=$DOCA_VERSION \
+  --build-arg RHCOS_VERSION=$RHCOS_VERSION \
+  --build-arg TARGET_IMAGE=$TARGET_IMAGE \
+  --build-arg D_DOCA_DISTRO=$DOCA_DISTRO \
+  --tag "rhcos-bfb:$RHCOS_VERSION-latest" .
 ```
 
 ### Creating disk boot images


### PR DESCRIPTION
update build to use the latest doca packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build instructions to use explicit Podman long-form flags.
  * Clarified Nvidia DPU stack variables: DOCA_VERSION now “3.1.0” and DOCA_DISTRO set to “rhel9.6”.
  * Introduced and documented new build arguments: TARGET_IMAGE and RHCOS_VERSION.
  * Retained D_ARCH and D_DOCA_VERSION, added D_DOCA_DISTRO.
  * Adjusted build-arg naming (TARGET_IMAGE replaces D_FINAL_BASE_IMAGE).
  * Specified build context with a trailing dot to run in the current directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->