### PR TITLE
Add argument for DOCA URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,36 @@ podman build -f rhcos-bfb.Containerfile \
   --tag "rhcos-bfb:$RHCOS_VERSION-latest" .
 ```
 
+Optionally, you can override the DOCA repository baseurl by either:
+
+**Option 1: Using environment variable**
+```bash
+export DOCA_BASEURL="<RPM_REPO_URL>"
+
+podman build -f rhcos-bfb.Containerfile \
+  --authfile $PULL_SECRET \
+  --build-arg D_ARCH=aarch64 \
+  --build-arg D_DOCA_VERSION=$DOCA_VERSION \
+  --build-arg RHCOS_VERSION=$RHCOS_VERSION \
+  --build-arg TARGET_IMAGE=$TARGET_IMAGE \
+  --build-arg D_DOCA_DISTRO=$DOCA_DISTRO \
+  --build-arg D_DOCA_BASEURL=$DOCA_BASEURL \
+  --tag "rhcos-bfb:$RHCOS_VERSION-latest" .
+```
+
+**Option 2: Directly via --build-arg**
+```bash
+podman build -f rhcos-bfb.Containerfile \
+  --authfile $PULL_SECRET \
+  --build-arg D_ARCH=aarch64 \
+  --build-arg D_DOCA_VERSION=$DOCA_VERSION \
+  --build-arg RHCOS_VERSION=$RHCOS_VERSION \
+  --build-arg TARGET_IMAGE=$TARGET_IMAGE \
+  --build-arg D_DOCA_DISTRO=$DOCA_DISTRO \
+  --build-arg D_DOCA_BASEURL="<RPM_REPO_URL>" \
+  --tag "rhcos-bfb:$RHCOS_VERSION-latest" .
+```
+
 ### Creating disk boot images
 ```bash
 skopeo copy containers-storage:localhost/rhcos-bfb:$RHCOS_VERSION-latest oci-archive:rhcos-bfb_$RHCOS_VERSION.ociarchive

--- a/rhcos-bfb.Containerfile
+++ b/rhcos-bfb.Containerfile
@@ -4,12 +4,14 @@ ARG RHCOS_VERSION
 ARG D_ARCH
 ARG D_CONTAINER_VER=0
 ARG D_DOCA_VERSION
+ARG D_DOCA_BASEURL
 
 FROM ${TARGET_IMAGE} AS base
 
 ARG RHCOS_VERSION
 ARG D_DOCA_VERSION
 ARG D_DOCA_DISTRO
+ARG D_DOCA_BASEURL
 ARG D_ARCH
 ARG OFED_SRC_LOCAL_DIR
 ARG IMAGE_TAG
@@ -24,7 +26,7 @@ RUN dnf config-manager --set-enabled codeready-builder-for-rhel-9-$(uname -m)-rp
   cat <<EOF > /etc/yum.repos.d/doca.repo
 [doca]
 name=Nvidia DOCA repository
-baseurl=https://linux.mellanox.com/public/repo/doca/${D_DOCA_VERSION}/${D_DOCA_DISTRO}/arm64-dpu/
+baseurl=\${D_DOCA_BASEURL:-https://linux.mellanox.com/public/repo/doca/${D_DOCA_VERSION}/${D_DOCA_DISTRO}/arm64-dpu/}
 gpgcheck=0
 enabled=1
 EOF


### PR DESCRIPTION
The DOCA repo URL is composed of several arguments aligned to the structure located under [1].

This change adds a parameter DOCA_BASEURL that can be passed on to the podman build command such that a custom repo can be used for constructing the BFB.

[1] - https://linux.mellanox.com/public/repo/doca/