### PR TITLE
Add 64k kernel support

### DIFF
--- a/rhcos-bfb.Containerfile
+++ b/rhcos-bfb.Containerfile
@@ -103,7 +103,13 @@ ARG D_DOCA_BASEURL_AUTH_CREDS
 ARG KERNEL_TYPE=default
 ARG IMAGE_TAG
 ARG COREOS_OPENCONTAINERS_IMAGE_VERSION
-RUN mkdir -p /tmp/rpms && source /etc/os-release && echo "${VERSION_ID}" > /etc/dnf/vars/releasever && dnf config-manager --set-enabled rhel-9-for-aarch64-baseos-eus-rpms && dnf config-manager --set-enabled rhel-9-for-aarch64-appstream-eus-rpms
+# Pin dnf releasever to the exact RHEL minor version (e.g. 9.6) from /etc/os-release
+# and enable EUS repos for exact kernel version matching
+RUN mkdir -p /tmp/rpms && \
+  source /etc/os-release && \
+  echo "${VERSION_ID}" > /etc/dnf/vars/releasever && \
+  dnf config-manager --set-enabled rhel-9-for-aarch64-baseos-eus-rpms && \
+  dnf config-manager --set-enabled rhel-9-for-aarch64-appstream-eus-rpms
 
 COPY --from=builder /root/rpms/*.rpm /tmp/rpms
 

--- a/rhcos-bfb.Containerfile
+++ b/rhcos-bfb.Containerfile
@@ -6,6 +6,7 @@ ARG D_DOCA_VERSION
 ARG D_DOCA_BASEURL
 ARG D_DOCA_BASEURL_AUTH=false
 ARG D_DOCA_BASEURL_AUTH_CREDS=
+ARG KERNEL_TYPE=default
 
 
 FROM ${BUILDER_IMAGE} AS builder
@@ -13,14 +14,19 @@ FROM ${BUILDER_IMAGE} AS builder
 ARG D_DOCA_VERSION
 ARG D_OFED_VERSION
 ARG D_CONTAINER_VER
+ARG KERNEL_TYPE=default
 
 
 ARG DOCA_SOURCES_URL="https://linux.mellanox.com/public/repo/doca/${D_DOCA_VERSION}/SOURCES"
 
 WORKDIR /root
 
-RUN KVER=$(ls /usr/lib/modules | head -n1) && \
-  echo "KVER=$KVER" >> /kernelver.env  
+RUN if [ "$KERNEL_TYPE" = "64k" ]; then \
+  KVER=$(ls /usr/lib/modules | grep 64k | head -n1); \
+  else \
+  KVER=$(ls /usr/lib/modules | grep -v 64k | head -n1); \
+  fi && \
+  echo "KVER=$KVER" >> /kernelver.env
 
 ARG D_OFED_SRC_ARCHIVE="MLNX_OFED_SRC-${D_OFED_SRC_TYPE}${D_OFED_VERSION}.tgz"
 
@@ -83,6 +89,7 @@ RUN cd /root/MLNX_OFED_SRC-${D_OFED_VERSION}/RPMS/redhat-release-*/aarch64 && \
   mv *.rpm /root/rpms && \
   mv /build/rpmbuild/RPMS/aarch64/*.rpm /root/rpms && \
   cd /root/rpms
+
 ######################################################################
 
 FROM ${TARGET_IMAGE} AS base
@@ -93,10 +100,10 @@ ARG D_DOCA_DISTRO
 ARG D_DOCA_BASEURL
 ARG D_DOCA_BASEURL_AUTH=false
 ARG D_DOCA_BASEURL_AUTH_CREDS
+ARG KERNEL_TYPE=default
 ARG IMAGE_TAG
 ARG COREOS_OPENCONTAINERS_IMAGE_VERSION
-
-RUN mkdir /tmp/rpms
+RUN mkdir -p /tmp/rpms && source /etc/os-release && echo "${VERSION_ID}" > /etc/dnf/vars/releasever && dnf config-manager --set-enabled rhel-9-for-aarch64-baseos-eus-rpms && dnf config-manager --set-enabled rhel-9-for-aarch64-appstream-eus-rpms
 
 COPY --from=builder /root/rpms/*.rpm /tmp/rpms
 
@@ -130,6 +137,17 @@ enabled=1
 EOF
 
 WORKDIR /
+
+RUN if [ "$KERNEL_TYPE" = "64k" ]; then \
+  echo "Installing 64k kernel variant..." && \
+  KVER=$(rpm -q kernel-core --queryformat '%{VERSION}-%{RELEASE}') && \
+  dnf install -y --setopt=install_weak_deps=False \
+    kernel-64k-core-${KVER} \
+    kernel-64k-modules-${KVER} \
+    kernel-64k-modules-core-${KVER} \
+    kernel-64k-modules-extra-${KVER} && \
+  rpm -e --nodeps kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra; \
+  fi
 
 RUN \
   # Setup /opt for package installations
@@ -250,8 +268,8 @@ RUN dnf -y install --setopt=install_weak_deps=False \
   device-mapper \
   lm_sensors \
   efibootmgr \
-  i2c-tools \ 
-  ipmitool \ 
+  i2c-tools \
+  ipmitool \
   nvmetcli\
   bf3-bmc-fw-signed bf3-bmc-gi-signed bf3-bmc-nic-fw* \
   bf3-cec-fw-signed \
@@ -307,6 +325,7 @@ RUN set -xe; kver=$(ls /usr/lib/modules); env DRACUT_NO_XATTR=1 dracut -vf /usr/
 
 LABEL "rhcos.version"="${RHCOS_VERSION}"
 LABEL "rhcos.doca.version"="${D_DOCA_VERSION}"
+LABEL "rhcos.kernel.type"="${KERNEL_TYPE}"
 LABEL "com.coreos.osname"=rhcos
 LABEL "rhcos.custom.tag"="${IMAGE_TAG}"
 LABEL "org.opencontainers.image.version"="${COREOS_OPENCONTAINERS_IMAGE_VERSION}"


### PR DESCRIPTION
## Summary
- Add `KERNEL_TYPE` build arg to support 64k page size kernel builds
- Auto-detect OS version and enable RHEL EUS repos for exact kernel version matching
- Install 64k kernel via `dnf install` from EUS repos instead of file copy
- Fix trailing whitespace on `i2c-tools` and `ipmitool` lines
- Add `rhcos.kernel.type` label to the image

## Usage
```bash
podman build --squash -f rhcos-bfb.Containerfile \
  --build-arg KERNEL_TYPE=64k \
  --build-arg BUILDER_IMAGE=<image-with-64k-kernel> \
  ...
```

When `KERNEL_TYPE=64k`, the build:
1. Selects the 64k kernel in the builder for OFED compilation
2. Pins `releasever` to the OS minor version (e.g. `9.6`)
3. Enables RHEL EUS repos to find the exact matching 64k kernel RPMs
4. Installs the 64k kernel packages via `dnf` and removes the default 4k kernel

When `KERNEL_TYPE=default` (or unset), behavior is unchanged.